### PR TITLE
Update naming of sanity check methods to pascal case

### DIFF
--- a/Auth/Auth/Config/AuthenticationConfig.cs
+++ b/Auth/Auth/Config/AuthenticationConfig.cs
@@ -64,7 +64,7 @@ namespace AeroGear.Mobile.Auth.Config
             /// <returns>AuthenticationConfigBuilder instance</returns>
             public AuthenticationConfigBuilder RedirectUri(string redirectUri)
             {
-                nonEmpty(redirectUri, "redirectUri");
+                NonEmpty(redirectUri, "redirectUri");
                 this.redirectUri = new Uri(redirectUri);
                 return this;
             }

--- a/Auth/Auth/User/User.cs
+++ b/Auth/Auth/User/User.cs
@@ -77,7 +77,7 @@ namespace Aerogear.Mobile.Auth.User
                      string refreshToken,
                      IList<UserRole> roles)
         {
-            this.Username = nonEmpty(username, "username");
+            this.Username = NonEmpty(username, "username");
             this.Firstname = firstName;
             this.Lastname = lastName;
             this.Email = email;
@@ -103,7 +103,7 @@ namespace Aerogear.Mobile.Auth.User
         /// <param name="role">role to be checked.</param>
         /// <param name="resourceId">resourceId related to role.</param>
         public bool HasResourceRole(string role, string resourceId) {
-            nonEmpty(role, "role");
+            NonEmpty(role, "role");
             return Roles.Contains(new UserRole(role, RoleType.RESOURCE, resourceId));
         }
 
@@ -113,7 +113,7 @@ namespace Aerogear.Mobile.Auth.User
         /// <returns><c>true</c>, if the passed in role is associated with this user, <c>false</c> otherwise.</returns>
         /// <param name="role">role to be checked.</param>
         public bool HasRealmRole(string role) {
-            nonEmpty(role, "role");
+            NonEmpty(role, "role");
             return Roles.Contains(new UserRole(role, RoleType.REALM, null));
         }
 
@@ -153,7 +153,7 @@ namespace Aerogear.Mobile.Auth.User
         }
 
         public UserBuilder WithUsername(string username) {
-            this.Username = nonEmpty(username, "username");
+            this.Username = NonEmpty(username, "username");
             return this;
         }
 

--- a/Auth/Auth/User/UserRole.cs
+++ b/Auth/Auth/User/UserRole.cs
@@ -36,8 +36,8 @@ namespace Aerogear.Mobile.Auth.User
         /// <param name="type">Role Type.</param>
         /// <param name="roleNamespace">Role name space/client ID.</param>
         public UserRole(string name, RoleType type, string roleNamespace) {
-            Name = nonEmpty(name, "name");
-            RoleType = nonNull(type, "type");
+            Name = NonEmpty(name, "name");
+            RoleType = NonNull(type, "type");
             RoleNamespace = roleNamespace;
         }
 

--- a/Core/Core.Tests/Utils/SanityCheckTests.cs
+++ b/Core/Core.Tests/Utils/SanityCheckTests.cs
@@ -7,11 +7,11 @@ namespace AeroGear.Mobile.Core.Utils
     public class SanityCheckTests
     {
         [Test]
-        public void testNonNull()
+        public void TestNonNull()
         {
             try
             {
-                SanityCheck.nonNull((String)null, "test-param");
+                SanityCheck.NonNull((String)null, "test-param");
                 Assert.Fail("null value has not been detected");
             }
             catch (ArgumentNullException ane)
@@ -21,11 +21,11 @@ namespace AeroGear.Mobile.Core.Utils
         }
 
         [Test]
-        public void testNonEmpty()
+        public void TestNonEmpty()
         {
             try
             {
-                SanityCheck.nonEmpty("     ", "empty-string");
+                SanityCheck.NonEmpty("     ", "empty-string");
                 Assert.Fail("empty value has not been detected");
             }
             catch (ArgumentException ae)
@@ -35,17 +35,17 @@ namespace AeroGear.Mobile.Core.Utils
         }
 
         [Test]
-        public void testNonEmptyNoTrim()
+        public void TestNonEmptyNoTrim()
         {
-            SanityCheck.nonEmpty("     ", "empty-string", false);
+			SanityCheck.NonEmpty("     ", "empty-string", false);
         }
 
         [Test]
-        public void testNonEmptyWithCustomMessage()
+        public void TestNonEmptyWithCustomMessage()
         {
             try
             {
-                SanityCheck.nonEmpty("     ",
+				SanityCheck.NonEmpty("     ",
                                      "Parameter '{0}' must be valorised and only spaces are not accepted",
                                      "testParam");
                 Assert.Fail("empty value has not been detected");

--- a/Core/Core/Configuration/MobileCoreJsonParser.cs
+++ b/Core/Core/Configuration/MobileCoreJsonParser.cs
@@ -15,7 +15,7 @@ namespace AeroGear.Mobile.Core.Configuration
 
         private MobileCoreJsonParser(Stream jsonStream)
         {
-            nonNull(jsonStream, "jsonStream");
+            NonNull(jsonStream, "jsonStream");
             var jsonText = ReadJsonStream(jsonStream);
             var jsonDocument = JsonValue.Parse(jsonText);
             ParseMobileCoreArray((JsonArray)jsonDocument["services"]);
@@ -23,14 +23,14 @@ namespace AeroGear.Mobile.Core.Configuration
 
         private MobileCoreJsonParser(string jsonString)
         {
-            nonNull(jsonString, "jsonString");
+            NonNull(jsonString, "jsonString");
             var jsonDocument = JsonValue.Parse(jsonString);
             ParseMobileCoreArray((JsonArray)jsonDocument["services"]);
         }
 
         private String ReadJsonStream(Stream jsonStream)
         {
-            nonNull(jsonStream, "jsonStream");
+            NonNull(jsonStream, "jsonStream");
             using (var streamReader = new StreamReader(jsonStream))
             {
                 return streamReader.ReadToEnd();
@@ -39,7 +39,7 @@ namespace AeroGear.Mobile.Core.Configuration
 
         private void ParseMobileCoreArray(JsonArray array)
         {
-            nonNull(array, "array");
+            NonNull(array, "array");
             int length = array.Count;
             for (int i = 0; (i < length); i++)
             {
@@ -50,7 +50,7 @@ namespace AeroGear.Mobile.Core.Configuration
 
         private void ParseConfigObject(JsonObject jsonObject)
         {
-            nonNull(jsonObject, "jsonObject");
+            NonNull(jsonObject, "jsonObject");
             var serviceConfigBuilder = ServiceConfiguration.Builder;
             serviceConfigBuilder.Id(jsonObject["id"]).Url(jsonObject["url"]).Type(jsonObject["type"]);
             JsonObject config = (JsonObject)jsonObject["config"];

--- a/Core/Core/Configuration/ServiceConfiguration.cs
+++ b/Core/Core/Configuration/ServiceConfiguration.cs
@@ -59,7 +59,7 @@ namespace AeroGear.Mobile.Core.Configuration
             private string url;
 
             public ServiceConfigurationBuilder Id(string id) {
-                nonEmpty(id, "id");
+                NonEmpty(id, "id");
                 this.id = id;
                 return this;
             }

--- a/Core/Core/Http/SystemNetHttpRequest.cs
+++ b/Core/Core/Http/SystemNetHttpRequest.cs
@@ -21,14 +21,14 @@ namespace AeroGear.Mobile.Core.Http
 
         internal SystemNetHttpRequest(HttpClient httpClient)
         {
-            nonNull(httpClient, "httpClient");
+            NonNull(httpClient, "httpClient");
             this.httpClient = httpClient;
         }
 
         public IHttpRequest AddHeader(string key, string value)
         {
-            nonNull(key, "header key");
-            nonNull(value, "header value");
+            NonNull(key, "header key");
+            NonNull(value, "header value");
             headers.Add(new KeyValuePair<string, string>(key, value));
             return this;
         }
@@ -36,8 +36,8 @@ namespace AeroGear.Mobile.Core.Http
 
         public IHttpRequestToBeExecuted Custom(string method, string url, byte[] body)
         {
-            nonNull(method, "method");
-            nonNull(url, "url");
+            NonNull(method, "method");
+            NonNull(url, "url");
             var message = new HttpRequestMessage();
             message.Method = new HttpMethod(method);
             message.RequestUri = new Uri(url);

--- a/Core/Core/MobileCore.cs
+++ b/Core/Core/MobileCore.cs
@@ -138,7 +138,7 @@ namespace AeroGear.Mobile.Core
         /// <returns>MobileCore singleton instance</returns>
         public static MobileCore Init(IPlatformInjector injector, Options options)
         {
-            nonNull<Options>(options, "init options");
+            NonNull<Options>(options, "init options");
             instance = new MobileCore(injector, options);
             return instance;
         }
@@ -180,7 +180,7 @@ namespace AeroGear.Mobile.Core
         private T GetInstance<T>(Type serviceClass, ServiceConfiguration serviceConfiguration)
             where T : IServiceModule
         {
-            nonNull<Type>(serviceClass, "serviceClass");
+            NonNull<Type>(serviceClass, "serviceClass");
             if (services.ContainsKey(serviceClass))
             {
                 return (T)services[serviceClass];

--- a/Core/Core/Utils/SanityCheck.cs
+++ b/Core/Core/Utils/SanityCheck.cs
@@ -15,7 +15,7 @@ namespace AeroGear.Mobile.Core.Utils
         /// <param name="value">String to be checked.</param>
         /// <param name="paramName">Parameter name to be used in the error message.</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static T nonNull<T>(T value, string paramName) {
+        public static T NonNull<T>(T value, string paramName) {
             if (value == null)
             {
                 throw new ArgumentNullException(String.Format(paramName));
@@ -30,9 +30,9 @@ namespace AeroGear.Mobile.Core.Utils
         /// <returns>The received value.</returns>
         /// <param name="value">String to be checked.</param>
         /// <param name="paramName">Parameter name to be used in the error message.</param>
-        public static string nonEmpty(string value, string paramName)
+        public static string NonEmpty(string value, string paramName)
         {
-            return nonEmpty(value, true, "'{0}' can't be empty or null", paramName);
+            return NonEmpty(value, true, "'{0}' can't be empty or null", paramName);
         }
 
         /// <summary>
@@ -44,9 +44,9 @@ namespace AeroGear.Mobile.Core.Utils
         /// <param name="value">String to be checked.</param>
         /// <param name="paramName">Parameter name to be used in the error message.</param>
         /// <param name="trim">whether the string must be trimmed or not.</param>
-        public static string nonEmpty(string value, String paramName, bool trim)
+		public static string NonEmpty(string value, String paramName, bool trim)
         {
-            return nonEmpty(value, trim, "'{0}' can't be empty or null", paramName);
+            return NonEmpty(value, trim, "'{0}' can't be empty or null", paramName);
         }
 
         /// <summary>
@@ -58,9 +58,9 @@ namespace AeroGear.Mobile.Core.Utils
         /// <param name="value">String to be checked.</param>
         /// <param name="customMessage">Custom message to be put into the exception.</param>
         /// <param name="messageParams">Parameters to be applied to the custom message.</param>
-        public static string nonEmpty(string value, string customMessage, params Object[] messageParams)
+        public static string NonEmpty(string value, string customMessage, params Object[] messageParams)
         {
-            return nonEmpty(value, true, customMessage, messageParams);
+            return NonEmpty(value, true, customMessage, messageParams);
         }
 
         /// <summary>
@@ -73,10 +73,10 @@ namespace AeroGear.Mobile.Core.Utils
         /// <param name="trim">Whether the string must be trimmed or not.</param>
         /// <param name="customMessage">Custom message to be put into the exception.</param>
         /// <param name="messageParams">Parameters to be applied to the custom message.</param>
-        public static string nonEmpty(string value, bool trim,
+		public static string NonEmpty(string value, bool trim,
                                       string customMessage, params Object[] messageParams)
         {
-            nonNull(value, String.Format(customMessage, messageParams));
+            NonNull(value, String.Format(customMessage, messageParams));
 
             if (value.Length == 0 || (trim && value.Trim().Length == 0))
             {

--- a/Example/Example.Android/Example.Android.csproj
+++ b/Example/Example.Android/Example.Android.csproj
@@ -46,6 +46,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="AeroGear.Mobile.Core.Platform.Android">
+      <HintPath>..\..\Core\Core.Platform.Android\bin\Debug\AeroGear.Mobile.Core.Platform.Android.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />

--- a/Example/Example.iOS/Example.iOS.csproj
+++ b/Example/Example.iOS/Example.iOS.csproj
@@ -106,6 +106,9 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="AeroGear.Mobile.Core.Platform.iOS">
+      <HintPath>..\..\Core\Core.Platform.iOS\bin\Debug\AeroGear.Mobile.Core.Platform.iOS.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\tab_about.png" />


### PR DESCRIPTION
## Motivation

Currently the sanity checks are using camel case, this isn't recommended by C# and we don't do it elsewhere.

## Description

Updates the method names to use pascal case.

## Progress

- [x] Refactor method names