### PR TITLE
[WIP] Appveyor install Android SDK API level 27

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: 0.1.0-BUILD{build}
 image: Visual Studio 2017
+install: install-android-sdk.ps1 
 before_build:
   - nuget restore
 build:

--- a/install-android-sdk.ps1
+++ b/install-android-sdk.ps1
@@ -1,0 +1,30 @@
+$AndroidToolPath = "${env:ProgramFiles(x86)}\Android\android-sdk\tools\android" 
+
+Function Get-AndroidSDKs() { 
+    $output = & $AndroidToolPath list sdk --all 
+    $sdks = $output |% { 
+        if ($_ -match '(?<index>\d+)- (?<sdk>.+), revision (?<revision>[\d\.]+)') { 
+            $sdk = New-Object PSObject 
+            Add-Member -InputObject $sdk -MemberType NoteProperty -Name Index -Value $Matches.index 
+            Add-Member -InputObject $sdk -MemberType NoteProperty -Name Name -Value $Matches.sdk 
+            Add-Member -InputObject $sdk -MemberType NoteProperty -Name Revision -Value $Matches.revision 
+            $sdk 
+        } 
+    } 
+    $sdks 
+}
+
+Function Install-AndroidSDK() { 
+    [CmdletBinding()] 
+    Param( 
+        [Parameter(Mandatory=$true, Position=0)] 
+        [PSObject[]]$sdks 
+    )
+
+    $sdkIndexes = $sdks |% { $_.Index } 
+    $sdkIndexArgument = [string]::Join(',', $sdkIndexes) 
+    Echo 'y' | & $AndroidToolPath update sdk -u -a -t $sdkIndexArgument 
+}
+
+$sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 27*' -or $_.name -like 'google apis*api 27' } 
+Install-AndroidSDK -sdks $sdks


### PR DESCRIPTION
## Motivation

We need to target latest Android SDK.

## Description

AppVeyor image currently supports 26. We can wait for 27 or do it by ourselves.

## Progress

- [x] Script to install Android API level 27 sdk support
- [ ] Get it working