### PR TITLE
Fix slow logout in AuthService

### DIFF
--- a/Core/Core/MobileCore.cs
+++ b/Core/Core/MobileCore.cs
@@ -102,7 +102,10 @@ namespace AeroGear.Mobile.Core
 
             if (options.HttpServiceModule == null)
             {
-                HttpClient httpClient = new HttpClient();
+                HttpClientHandler httpClientHandler = new HttpClientHandler();
+                httpClientHandler.AllowAutoRedirect = false;
+
+                HttpClient httpClient = new HttpClient(httpClientHandler);
                 httpClient.Timeout = TimeSpan.FromSeconds(DEFAULT_TIMEOUT);
                 var httpServiceModule = new SystemNetHttpServiceModule(httpClient);
                 var configuration = GetServiceConfiguration(httpServiceModule.Type);

--- a/Core/Core/MobileCore.cs
+++ b/Core/Core/MobileCore.cs
@@ -103,7 +103,7 @@ namespace AeroGear.Mobile.Core
             if (options.HttpServiceModule == null)
             {
                 HttpClientHandler httpClientHandler = new HttpClientHandler();
-                httpClientHandler.AllowAutoRedirect = false;
+                httpClientHandler.AllowAutoRedirect = options.HttpAllowAutoRedirect;
 
                 HttpClient httpClient = new HttpClient(httpClientHandler);
                 httpClient.Timeout = TimeSpan.FromSeconds(DEFAULT_TIMEOUT);

--- a/Core/Core/Options.cs
+++ b/Core/Core/Options.cs
@@ -14,6 +14,7 @@ namespace AeroGear.Mobile.Core
 
         //  Don't have a default implementation because it should use configuration
         public IHttpServiceModule HttpServiceModule {get; private set;}
+        public bool HttpAllowAutoRedirect { get; private set; }
 
         public ILogger Logger { get; private set; }
 
@@ -26,6 +27,7 @@ namespace AeroGear.Mobile.Core
 
         public Options()
         {
+            HttpAllowAutoRedirect = false;
             ConfigFileName = MobileCore.DEFAULT_CONFIG_FILE_NAME;            
         }
 
@@ -35,6 +37,7 @@ namespace AeroGear.Mobile.Core
             private String configFileName;
             private string configJSON;
             private IHttpServiceModule httpServiceModule;
+            private bool httpAllowAutoRedirect = false;
 
             internal OptionsBuilder() { }
 
@@ -84,6 +87,19 @@ namespace AeroGear.Mobile.Core
             }
 
             /// <summary>
+            /// Set whether the default HTTP Client should allow redirects.
+            /// This does not apply when specifying a custom HTTP Client using
+            /// <see cref="HttpServiceModule(IHttpServiceModule)"/>.
+            /// </summary>
+            /// <returns>itself</returns>
+            /// <param name="allowAutoRedirect">If set to <c>true</c> allow auto redirect.</param>
+            public OptionsBuilder HttpAllowAutoRedirect(bool allowAutoRedirect)
+            {
+                this.httpAllowAutoRedirect = allowAutoRedirect;
+                return this;
+            }
+
+            /// <summary>
             /// Creates options to be used to initialize the core.
             /// </summary>
             /// <returns>initialization options</returns>
@@ -94,6 +110,7 @@ namespace AeroGear.Mobile.Core
                 options.HttpServiceModule = httpServiceModule;
                 options.Logger = logger;
                 options.ConfigJson = configJSON;
+                options.HttpAllowAutoRedirect = httpAllowAutoRedirect;
                 return options;
             }
         }


### PR DESCRIPTION
## Motivation

Currently the logout method takes a long time to complete. This causes any logic that should be performed after logout is complete, such as navigation, to also take a long time to complete.

## Description

Implement the suggestion in https://github.com/aidenkeating/aerogear-xamarin-sdk/pull/3#issue-183886662 

## Progress

- [x] Set AllowAutoRedirect to false

# Verification Steps

1. Run the app from master and confirm logout navigation for iOS takes a long time.
2. Run the app from `aidenkeating:fix-slow-logout-authservice` and confirm logout navigation for iOS is as expected.