### PR TITLE
[INVESTIGATION] Implemented automatic platform initialization+services

### DIFF
--- a/Auth/Auth.Platform.Android/Auth.Platform.Android.csproj
+++ b/Auth/Auth.Platform.Android/Auth.Platform.Android.csproj
@@ -87,10 +87,6 @@
       <Project>{F1EA4BBA-D775-45C0-99DA-DB0590BEE87E}</Project>
       <Name>Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Core\Core.Platform.Android\Core.Platform.Android.csproj">
-      <Project>{E30A4499-8EF8-4542-AAF9-C9D30A543752}</Project>
-      <Name>Core.Platform.Android</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets" Condition="Exists('..\..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets')" />

--- a/Auth/Auth.Platform.Android/AuthService.cs
+++ b/Auth/Auth.Platform.Android/AuthService.cs
@@ -5,9 +5,6 @@ using AeroGear.Mobile.Auth.Authenticator;
 using AeroGear.Mobile.Auth.Config;
 using AeroGear.Mobile.Auth.Credentials;
 using AeroGear.Mobile.Core;
-using AeroGear.Mobile.Core.Configuration;
-using AeroGear.Mobile.Core.Storage;
-using AeroGear.Mobile.Auth;
 using Android.Content;
 
 namespace AeroGear.Mobile.Auth
@@ -17,26 +14,9 @@ namespace AeroGear.Mobile.Auth
     /// </summary>
     public class AuthService : AbstractAuthService
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:AeroGear.Mobile.Auth.AuthService"/> class.
-        /// </summary>
-        /// <param name="mobileCore">Mobile core.</param>
-        /// <param name="serviceConfig">Service configuration.</param>
-        public AuthService(MobileCore mobileCore = null, ServiceConfiguration serviceConfig = null) : base(mobileCore, serviceConfig)
+        public AuthService()
         {
-            var storageManager = new StorageManager("AeroGear.Mobile.Auth.Credentials", Android.App.Application.Context);
-            CredentialManager = new CredentialManager(storageManager);
         }
-
-        /// <summary>
-        /// Provide authentication configuration to the service.
-        /// </summary>
-        /// <param name="authConfig">Authentication config.</param>
-        public override void Configure(AuthenticationConfig authConfig)
-        {
-            Authenticator = new OIDCAuthenticator(authConfig, KeycloakConfig, CredentialManager, MobileCore.HttpLayer, MobileCore.Logger);
-        }
-
 
         /// <summary>
         /// Retrieves the current authenticated user. If there is no currently
@@ -65,14 +45,13 @@ namespace AeroGear.Mobile.Auth
         }
 
         /// <summary>
-        /// Initializes the service and pass the configuration to be used to configure it
+        /// Initializes the service with the provided authentication configuration.
         /// </summary>
-        /// <returns>The initialized service.</returns>
-        /// <param name="core">The Mobile core instance. If <code>null</code> then <code>MobileCore.Instance</code> is used.</param>
-        /// <param name="config">The service configuration. If <code>null</code> then <code>MobileCore.GetServiceConfiguration(Type)</code> is used.</param>
-        public static IAuthService InitializeService(MobileCore core = null, ServiceConfiguration config = null)
+        /// <returns>The init.</returns>
+        /// <param name="authConfig">Auth config.</param>
+        public override void Init(AuthenticationConfig authConfig)
         {
-            return MobileCore.Instance.RegisterService<IAuthService>(new AuthService(core, config));
+            Authenticator = new OIDCAuthenticator(authConfig, KeycloakConfig, CredentialManager, MobileCore.HttpLayer, MobileCore.Logger);
         }
     }
 }

--- a/Auth/Auth.Platform.iOS/Auth.Platform.iOS.csproj
+++ b/Auth/Auth.Platform.iOS/Auth.Platform.iOS.csproj
@@ -74,10 +74,6 @@
       <Project>{F1EA4BBA-D775-45C0-99DA-DB0590BEE87E}</Project>
       <Name>Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Core\Core.Platform.iOS\Core.Platform.iOS.csproj">
-      <Project>{C5B8A6AF-90D0-43DC-B097-A5F3CEB01E9F}</Project>
-      <Name>Core.Platform.iOS</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project="..\..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets" Condition="Exists('..\..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets')" />

--- a/Auth/Auth.Platform.iOS/AuthService.cs
+++ b/Auth/Auth.Platform.iOS/AuthService.cs
@@ -8,23 +8,17 @@ using AeroGear.Mobile.Core;
 using AeroGear.Mobile.Core.Configuration;
 using AeroGear.Mobile.Core.Storage;
 using AeroGear.Mobile.Auth;
+using AeroGear.Mobile.Core.Utils;
 
 namespace AeroGear.Mobile.Auth
 {
     public class AuthService : AbstractAuthService
     {
-        public AuthService(MobileCore mobileCore = null, ServiceConfiguration serviceConfig = null) : base(mobileCore, serviceConfig)
+        public AuthService()
         {
-            var storageManager = new StorageManager("AeroGear.Mobile.Auth.Credentials");
-            CredentialManager = new CredentialManager(storageManager);
         }
 
-        /// <summary>
-        /// Provide authentication configuration to the service.
-        /// </summary>
-        /// <param name="authConfig">Authentication config.</param>
-        public override void Configure(AuthenticationConfig authConfig)
-        {
+        override public void Init(AuthenticationConfig authConfig) {
             Authenticator = new OIDCAuthenticator(authConfig, KeycloakConfig, CredentialManager, MobileCore.HttpLayer, MobileCore.Logger);
         }
 
@@ -41,17 +35,6 @@ namespace AeroGear.Mobile.Auth
             }
             var parsedCredential = new OIDCCredential(serializedCredential);
             return User.NewUser().FromUnverifiedCredential(parsedCredential, KeycloakConfig.ResourceId);
-        }
-       
-        /// <summary>
-        /// Initializes the service and pass the configuration to be used to configure it
-        /// </summary>
-        /// <returns>The initialized service.</returns>
-        /// <param name="core">The Mobile core instance. If <code>null</code> then <code>MobileCore.Instance</code> is used.</param>
-        /// <param name="config">The service configuration. If <code>null</code> then <code>MobileCore.GetServiceConfiguration(Type)</code> is used.</param>
-        public static IAuthService InitializeService(MobileCore core = null, ServiceConfiguration config = null)
-        {
-            return MobileCore.Instance.RegisterService<IAuthService>(new AuthService(core, config));
         }
     }
 }

--- a/Auth/Auth/AbstractAuthService.cs
+++ b/Auth/Auth/AbstractAuthService.cs
@@ -6,6 +6,8 @@ using AeroGear.Mobile.Auth.Config;
 using AeroGear.Mobile.Auth.Credentials;
 using AeroGear.Mobile.Core;
 using AeroGear.Mobile.Core.Configuration;
+using AeroGear.Mobile.Core.Storage;
+using AeroGear.Mobile.Core.Utils;
 using static AeroGear.Mobile.Core.Utils.SanityCheck;
 
 namespace AeroGear.Mobile.Auth
@@ -16,32 +18,31 @@ namespace AeroGear.Mobile.Auth
     public abstract class AbstractAuthService : IAuthService
     {
         protected CredentialManager CredentialManager { get; set; }
-        protected readonly KeycloakConfig KeycloakConfig;
+        protected KeycloakConfig KeycloakConfig;
         protected AuthenticationConfig AuthenticationConfig { get; private set; }
-        protected readonly MobileCore MobileCore;
+        protected MobileCore MobileCore;
         protected IAuthenticator Authenticator { get; set; }
         public string Type => "keycloak";
         public bool RequiresConfiguration => true;
 
         public abstract User CurrentUser();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:AeroGear.Mobile.Auth.AbstractAuthService"/> class.
-        /// </summary>
-        /// <param name="mobileCore">Mobile core.</param>
-        /// <param name="serviceConfig">Service config.</param>
-        public AbstractAuthService(MobileCore mobileCore = null, ServiceConfiguration serviceConfig = null)
+        public AbstractAuthService() 
         {
-            MobileCore = mobileCore ?? MobileCore.Instance;
-            var serviceConfiguration = NonNull(serviceConfig ?? MobileCore.GetServiceConfiguration(Type), "serviceConfig");
-            KeycloakConfig = new KeycloakConfig(serviceConfiguration);
+            var storageManager = ServiceFinder.Resolve<IStorageManager>();
+            CredentialManager = new CredentialManager(storageManager);
         }
 
         /// <summary>
         /// Configure the service module.
         /// </summary>
-        /// <param name="authConfig">Authentication configuration.</param>
-        public abstract void Configure(AuthenticationConfig authConfig);
+        /// <param name="serviceConfig">Service configuration.</param>
+        public void Configure(MobileCore mobileCore, ServiceConfiguration serviceConfig) 
+        {
+            MobileCore = mobileCore ?? MobileCore.Instance;
+            var serviceConfiguration = NonNull(serviceConfig ?? MobileCore.GetServiceConfiguration(Type), "serviceConfig");
+            KeycloakConfig = new KeycloakConfig(serviceConfiguration);    
+        }
 
         /// <summary>
         /// Initiate an authentication flow.
@@ -69,5 +70,7 @@ namespace AeroGear.Mobile.Auth
         {
             return Authenticator.Logout(user);
         }
+
+        public abstract void Init(AuthenticationConfig authConfig);
     }
 }

--- a/Auth/Auth/IAuthService.cs
+++ b/Auth/Auth/IAuthService.cs
@@ -24,16 +24,13 @@ namespace AeroGear.Mobile.Auth
         /// <returns><see cref="Task"/></returns>
         Task<User> Authenticate(IAuthenticateOptions authenticateOptions);
 
-        /// <summary>
-        /// Configure the service module.
-        /// </summary>
-        /// <param name="authConfig">Authentication configuration.</param>
-        void Configure(AuthenticationConfig authConfig);
 
         /// <summary>
         /// Logout the specified user.
         /// </summary>
         /// <returns><see cref="Task"/></returns>
         Task<bool> Logout(User user);
+
+        void Init(AuthenticationConfig authConfig);
     }
 }

--- a/Core/Core.Platform.Android/Core.Platform.Android.csproj
+++ b/Core/Core.Platform.Android/Core.Platform.Android.csproj
@@ -48,6 +48,14 @@
       <Project>{f1ea4bba-d775-45c0-99da-db0590bee87e}</Project>
       <Name>Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Auth\Auth\Auth.csproj">
+      <Project>{55FF3B02-07D1-46F3-B0D5-584D3B98467E}</Project>
+      <Name>Auth</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Auth\Auth.Platform.Android\Auth.Platform.Android.csproj">
+      <Project>{ACEB8935-989F-46CA-8F0F-FBA3B358C70C}</Project>
+      <Name>Auth.Platform.Android</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">
@@ -63,6 +71,18 @@
     </Reference>
     <Reference Include="System.Xml">
       <HintPath>..\..\..\..\..\..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\System.Xml.dll</HintPath>
+    </Reference>
+    <Reference Include="CommonServiceLocator">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\CommonServiceLocator.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Abstractions">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Container">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Container.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.ServiceLocation">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.ServiceLocation.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup />

--- a/Core/Core.Platform.Android/MobileCoreAndroid.cs
+++ b/Core/Core.Platform.Android/MobileCoreAndroid.cs
@@ -1,4 +1,9 @@
-﻿using AeroGear.Mobile.Core.Platform.Android;
+﻿using AeroGear.Mobile.Auth;
+using AeroGear.Mobile.Core.Logging;
+using AeroGear.Mobile.Core.Platform.Android;
+using AeroGear.Mobile.Core.Storage;
+using AeroGear.Mobile.Core.Utils;
+using Android.App;
 using Android.Content;
 using System.Reflection;
 
@@ -47,9 +52,18 @@ namespace AeroGear.Mobile.Core
         /// <param name="options">additional initialization options</param>
         public static void Init(Assembly assembly, Context appContext, Options options)
         {
+            // TODO: check if already initialized
+            RegisterServices();
             IPlatformInjector platformInjector = new AndroidPlatformInjector(appContext);
             platformInjector.ExecutingAssembly = assembly;
             MobileCore.Init(platformInjector, options);
+        }
+
+        private static void RegisterServices()
+        {
+            ServiceFinder.RegisterType<IAuthService, AuthService>();
+            ServiceFinder.RegisterType<ILogger, AndroidLogger>();
+            ServiceFinder.RegisterInstance<IStorageManager>(new StorageManager("AeroGear.Mobile.Auth.Credentials", Application.Context.ApplicationContext));
         }
     }
 }

--- a/Core/Core.Platform.Android/packages.config
+++ b/Core/Core.Platform.Android/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="monoandroid71" developmentDependency="true" />  
+  <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="monoandroid71" developmentDependency="true" />
+  <package id="Unity" version="5.8.6" targetFramework="monoandroid80" />
 </packages>

--- a/Core/Core.Platform.iOS/Core.Platform.iOS.csproj
+++ b/Core/Core.Platform.iOS/Core.Platform.iOS.csproj
@@ -55,11 +55,21 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.IO" />
-    <Reference Include="System.Reflection" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="CommonServiceLocator">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\CommonServiceLocator.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Abstractions">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Container">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Container.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.ServiceLocation">
+      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.ServiceLocation.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MobileCoreIOS.cs" />
@@ -74,6 +84,14 @@
       <Project>{f1ea4bba-d775-45c0-99da-db0590bee87e}</Project>
       <Name>Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Auth\Auth\Auth.csproj">
+      <Project>{55FF3B02-07D1-46F3-B0D5-584D3B98467E}</Project>
+      <Name>Auth</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Auth\Auth.Platform.iOS\Auth.Platform.iOS.csproj">
+      <Project>{CBB87B9E-D526-46B1-B05A-AD3D383EACED}</Project>
+      <Name>Auth.Platform.iOS</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">
@@ -83,7 +101,6 @@
   <ItemGroup>
     <Folder Include="Storage\" />
   </ItemGroup>
-  <Import Project="..\Core.Platform.Shared\Core.Platform.Shared.projitems" Label="Shared" Condition="Exists('..\Core.Platform.Shared\Core.Platform.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project="..\..\..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets" Condition="Exists('..\..\..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets')" />
   <Import Project="..\..\..\packages\Xamarin.Forms.2.5.0.280555\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.2.5.0.280555\build\netstandard1.0\Xamarin.Forms.targets')" />

--- a/Core/Core.Platform.iOS/MobileCoreIOS.cs
+++ b/Core/Core.Platform.iOS/MobileCoreIOS.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using System.Reflection;
+using AeroGear.Mobile.Auth;
+using AeroGear.Mobile.Core.Logging;
+using AeroGear.Mobile.Core.Storage;
+using AeroGear.Mobile.Core.Utils;
 
 namespace AeroGear.Mobile.Core
 {
@@ -40,9 +44,17 @@ namespace AeroGear.Mobile.Core
         /// <param name="options">additional initialization options</param>
         public static MobileCore Init(Assembly assembly, Options options)
         {
+            RegisterServices();
             IPlatformInjector platformInjector = new IOSPlatformInjector();
             platformInjector.ExecutingAssembly = assembly;
             return MobileCore.Init(platformInjector, options);
+        }
+
+        private static void RegisterServices()
+        {
+            ServiceFinder.RegisterType<IAuthService, AuthService>();
+            ServiceFinder.RegisterType<ILogger, IOSLogger>();
+            ServiceFinder.RegisterType<IStorageManager, StorageManager>();
         }
     }
 }

--- a/Core/Core.Platform.iOS/Storage/StorageManager.cs
+++ b/Core/Core.Platform.iOS/Storage/StorageManager.cs
@@ -5,16 +5,12 @@ namespace AeroGear.Mobile.Core.Storage
 {
     public class StorageManager : IStorageManager
     {
+        private const string DEFAULT_STORAGE = "AeroGear.Mobile.Auth.Credentials";
         private readonly SecureKeyValueStore KeyValStore;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:AeroGear.Mobile.Core.Storage.StorageManager"/> class.
-        /// </summary>
-        /// <param name="storeName">Store name.</param>
-        /// <param name="context">Context.</param>
-        public StorageManager(string storeName)
+        public StorageManager()
         {
-            KeyValStore = new SecureKeyValueStore(storeName);
+            KeyValStore = new SecureKeyValueStore(DEFAULT_STORAGE);
         }
 
         /// <summary>

--- a/Core/Core.Platform.iOS/packages.config
+++ b/Core/Core.Platform.iOS/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NuGet.Build.Packaging" version="0.2.2" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Unity" version="5.8.6" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.5.1.444934" targetFramework="xamarinios10" />
 </packages>

--- a/Core/Core.Tests/DummyModuleInitTest.cs
+++ b/Core/Core.Tests/DummyModuleInitTest.cs
@@ -49,6 +49,11 @@ namespace AeroGear.Mobile.Core.Tests
                 var serviceConfig = MobileCore.Instance.GetServiceConfiguration("dummy");
                 MobileCore.Instance.RegisterService<IDummyModule>(new DummyModule(serviceConfig));
             }
+
+            public void Configure(MobileCore core, ServiceConfiguration authConfig)
+            {
+                
+            }
         }
 
         [SetUp]

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="System.Json" Version="4.4.0" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
+    <PackageReference Include="Unity" Version="5.8.6" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Storage\" />

--- a/Core/Core/IServiceModule.cs
+++ b/Core/Core/IServiceModule.cs
@@ -30,5 +30,7 @@ namespace AeroGear.Mobile.Core
         /// Called when singleThreadService destroyed.
         /// </summary>
         void Destroy();
+
+        void Configure(MobileCore core, ServiceConfiguration authConfig);
     }
 }

--- a/Core/Core/MobileCore.cs
+++ b/Core/Core/MobileCore.cs
@@ -7,6 +7,7 @@ using AeroGear.Mobile.Core.Exception;
 using AeroGear.Mobile.Core.Http;
 using System.Reflection;
 using System.Net.Http;
+using AeroGear.Mobile.Core.Utils;
 
 namespace AeroGear.Mobile.Core
 {
@@ -198,6 +199,22 @@ namespace AeroGear.Mobile.Core
             if (services.ContainsKey(serviceClass))
             {
                 return (T)services[serviceClass];
+            }
+
+            if (ServiceFinder.IsRegistered<T>())
+            {
+                IServiceModule serviceModule = ServiceFinder.Resolve<T>() as IServiceModule;
+
+                ServiceConfiguration conf = serviceConfiguration ?? GetServiceConfiguration(serviceModule.Type);
+
+                if (conf == null && serviceModule.RequiresConfiguration) {
+                    throw new System.Exception("No configuraton found for service");
+                }
+
+                serviceModule.Configure(this, conf);
+
+                services[serviceClass] = serviceModule;
+                return (T)serviceModule;
             }
             // There are no services registered for this interface.
             throw new ServiceModuleInstanceNotFoundException(String.Format("No instance has been registered for interface {0}", serviceClass.Name));

--- a/Core/Core/Utils/ServiceFinder.cs
+++ b/Core/Core/Utils/ServiceFinder.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Unity;
+
+namespace AeroGear.Mobile.Core.Utils
+{
+    public static class ServiceFinder
+    {
+        private static readonly UnityContainer Container = new UnityContainer();
+
+        /// <summary>
+        ///     Resolve the correct implementation for the type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>an instance of the correct implementation class</returns>
+        public static T Resolve<T>()
+        {
+            return Container.Resolve<T>();
+        }
+
+        public static void RegisterType<TFrom, TTo>() where TTo : TFrom
+        {
+            Container.RegisterType<TFrom, TTo>();
+        }
+
+        public static void RegisterInstance<TInstance>(TInstance instance)
+        {
+            Container.RegisterInstance<TInstance>(instance);
+        }
+
+        public static bool IsRegistered<TInstance>()
+        {
+            return Container.IsRegistered<TInstance>();
+        }
+
+    }
+}

--- a/Example/Example.Android/Example.Android.csproj
+++ b/Example/Example.Android/Example.Android.csproj
@@ -46,9 +46,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="AeroGear.Mobile.Core.Platform.Android">
-      <HintPath>..\..\Core\Core.Platform.Android\bin\Debug\AeroGear.Mobile.Core.Platform.Android.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />

--- a/Example/Example.Android/MainActivity.cs
+++ b/Example/Example.Android/MainActivity.cs
@@ -33,9 +33,6 @@ namespace Example.Android
             Instance = this;
             var app = new App();
             MobileCoreAndroid.Init(app.GetType().Assembly,ApplicationContext);
-            var authService = AuthService.InitializeService();
-            var authConfig = AuthenticationConfig.Builder.RedirectUri("org.aerogear.mobile.example:/callback").Build();
-            authService.Configure(authConfig);
             LoadApplication(app);
         }
 

--- a/Example/Example.iOS/AppDelegate.cs
+++ b/Example/Example.iOS/AppDelegate.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using AeroGear.Mobile.Auth;
-using AeroGear.Mobile.Auth.Config;
-using AeroGear.Mobile.Core;
-using AeroGear.Mobile.Core.Configuration;
+﻿using AeroGear.Mobile.Core;
 using FFImageLoading.Forms.Touch;
 using Foundation;
 using ImageCircle.Forms.Plugin.iOS;
 using UIKit;
-using static AeroGear.Mobile.Core.Configuration.ServiceConfiguration;
 
 namespace Example.iOS
 {
@@ -29,9 +24,6 @@ namespace Example.iOS
             global::Xamarin.Forms.Forms.Init();
             var xamApp = new App();
             MobileCore core = MobileCoreIOS.Init(xamApp.GetType().Assembly);
-            var authService = AuthService.InitializeService();
-            var authConfig = AuthenticationConfig.Builder.RedirectUri("org.aerogear.mobile.example:/callback").Build();
-            authService.Configure(authConfig);
             LoadApplication(xamApp);
             CachedImageRenderer.Init();
             ImageCircleRenderer.Init();

--- a/Example/Example/Views/Pages/AuthPage.xaml.cs
+++ b/Example/Example/Views/Pages/AuthPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using AeroGear.Mobile.Auth;
+using AeroGear.Mobile.Auth.Config;
 using AeroGear.Mobile.Core;
 using Example.Auth;
 using Xamarin.Forms;
@@ -19,6 +20,8 @@ namespace Example.Views.Pages
         public void OnAuthenticateClicked(object sender, EventArgs args)
         {
             IAuthService service = MobileCore.Instance.GetInstance<IAuthService>();
+            var authConfig = AuthenticationConfig.Builder.RedirectUri("org.aerogear.mobile.example:/callback").Build();
+            service.Init(authConfig);
             var authOptions = DependencyService.Get<IAuthenticateOptionsProvider>().GetOptions();
             service.Authenticate(authOptions).ContinueWith(result =>
             {

--- a/Tests/iOS.Tests/Storage/StorageManagerTests.cs
+++ b/Tests/iOS.Tests/Storage/StorageManagerTests.cs
@@ -12,7 +12,8 @@ namespace iOS.Tests.Storage
         [SetUp]
         public void Setup()
         {
-            Store = new StorageManager("org.aerogear.Core-Platform-iOS-Tests");
+            //Store = new StorageManager("org.aerogear.Core-Platform-iOS-Tests");
+            Store = new StorageManager();
         }
 
         [Test]


### PR DESCRIPTION
**!!!!!!!    THIS IS AN INVESTIGATION TASK: DO NOT MERGE    !!!!!!!**

## Motivation

We desired to have a way to initialize the platform and all the provided services without any intervention from the user.

JIRA: https://issues.jboss.org/browse/AEROGEAR-2611

## Description

In this pull request, I've used the `ServiceFinder` class to register the instances of the platform specific services so that shared projects could get the service implementation by simply asking such object to the `ServiceFinder` itself.
The initialization of the `ServiceFinder` object is done automatically inside the `MobileCoreIOS/Andoid` class, so that user doesn't have to do anything.

## Progress

- [x] Add ServiceFinder class
- [x] Update the Auth.Android and Core.Platform.Android projects
- [x] Update the Auth.iOS and Core.Platform.iOS projects
- [x] Update the Core project to use the ServiceFinder
- [x] Change the AuthService interface/flow so that it is again similar to what we used in other SDKs

## Additional Notes

With this approach I've been able to move more code to the base classes and the percent of shared code is now greater.
