### PR TITLE
Add documentation generation script to be inline with other SDKs

### DIFF
--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -6,7 +6,7 @@
 # Using yum: yum -y install doxygen
 
 # Confirm that Doxygen is installed. If it's not exit and provide an error.
-command -v foo >/dev/null 2>&1 || { echo >&2 "Doxygen is not found. To install, run: (yum) yum -y install doxygen | (Homebrew) brew install doxygen."; exit 1; }
+command -v doxygen >/dev/null 2>&1 || { echo >&2 "Doxygen is not found. To install, run: (yum) yum -y install doxygen | (Homebrew) brew install doxygen."; exit 1; }
 
 echo "Creating documentation for the Xamarin SDK."
 doxygen Documentations/Doxyfile

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,14 @@
+# Generate Doxygen documentation for the AeroGear Xamarin SDK.
+# NOTE: This script requires Doxygen to be installed and available on the path.
+#
+# Installation:
+# macOS using Homebrew: brew install doxygen
+# Using yum: yum -y install doxygen
+
+# Confirm that Doxygen is installed. If it's not exit and provide an error.
+command -v foo >/dev/null 2>&1 || { echo >&2 "Doxygen is not found. To install, run: (yum) yum -y install doxygen | (Homebrew) brew install doxygen."; exit 1; }
+
+echo "Creating documentation for the Xamarin SDK."
+doxygen Documentations/Doxyfile
+
+echo "Documentation is stored in the Documentations/html/ directory."


### PR DESCRIPTION
## Description
Currently other AeroGear SDKs contain a scripts directory with an
API documentation generation script. This change provides a script
that will check if Doxygen is installed. If it is then it will
perform the generation of the documentation and inform the user of
the output directory.


See: https://github.com/aerogear/aerogear-ios-sdk/blob/master/scripts/docs.sh