### PR TITLE
fix: Use type instead of id for config fetching

### DIFF
--- a/Core/Core/Configuration/MobileCoreJsonParser.cs
+++ b/Core/Core/Configuration/MobileCoreJsonParser.cs
@@ -64,7 +64,7 @@ namespace AeroGear.Mobile.Core.Configuration
             }
 
             ServiceConfiguration serviceConfig = serviceConfigBuilder.Build();
-            values[serviceConfig.Id] = serviceConfig;
+            values[serviceConfig.Type] = serviceConfig;
         }
 
         /// <summary>


### PR DESCRIPTION
## Motivation

Use type for fetching mobile configurations instead of name.
Name is just human readable name and it's not guaranteed to be unique.
Id will be used only for custom runtime connectors fetching (separate ticket).

This change is fixing SDK to work with current mobile config.

See: groups.google.com/forum/#!topic/aerogear/1hxhEPBASVY