### PR TITLE
Workaround to make the project work on VS 7.5 for mac

### DIFF
--- a/Example/Example.iOS/Example.iOS.csproj
+++ b/Example/Example.iOS/Example.iOS.csproj
@@ -28,6 +28,7 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
## Motivation

The xamarin IOS application does not works anymore if run inside VisualStudio 7.5 for mac

Details about the issue can be found here:

[https://github.com/xamarin/xamarin-macios/issues/3830](https://github.com/xamarin/xamarin-macios/issues/3830)

## Description

This PR contains a workaround to make the app work with VS 7.5 for mac.
The final fixes will be released in few months, so we should stick with this for quite some time.
