### PR TITLE
Role Name must be public

### DIFF
--- a/Auth/Auth/User/UserRole.cs
+++ b/Auth/Auth/User/UserRole.cs
@@ -24,7 +24,7 @@ namespace AeroGear.Mobile.Auth
         /// <summary>
         /// Role name. Can't be null.
         /// </summary>
-        private string Name { get; }
+        public string Name { get; }
 
         /// <summary>
         /// Role name space/client ID. Can be null.


### PR DESCRIPTION
## Motivation

Role Name was private. That prevents from creating the role view in the showcase

## Description

There was no way to get the role name.