### PR TITLE
release_sdk, script updated to support $configuration$ in .nuspec

### DIFF
--- a/scripts/modules/sdk_operations.js
+++ b/scripts/modules/sdk_operations.js
@@ -102,9 +102,9 @@ async function updateDependencies(doc, config, projPath, dryrun) {
  */
 async function packNuGets(doc, projConfig, projPath, dryrun) {
     const dir = `${__dirname}/../../`;
-    const nuSpecPath = `${dir}/${projConfig['nuspec']}`
+    const nuSpecPath =`${dir}/${projConfig['nuspec']}`
     try {
-        const result = await execFile("nuget", ["pack", nuSpecPath, '-OutputDirectory', `${dir}/nugets`])
+        const result = await execFile("nuget", ["pack", nuSpecPath, '-OutputDirectory', `${dir}/nugets`,'-Prop',`Configuration=${projConfig['configuration']}`])        
         console.log(result.stdout)
         console.log(`Packed package ${chalk.green(projConfig['package'])}`)
     } catch (e) {


### PR DESCRIPTION
## Motivation

release_sdk.js script stopped packing NuGets after change in https://github.com/aerogear/aerogear-xamarin-sdk/pull/67

## Description
Added new `--configuration` parameter to be set.
`./release_sdk.js pack all`  - by default it uses `Release` configuration, but you can change it
`./release_sdk.js pack all --configuration Something`