### PR TITLE
Fixed getting service configuration by type

### DIFF
--- a/Core/Core.Tests/Resources/mobile-services.json
+++ b/Core/Core.Tests/Resources/mobile-services.json
@@ -33,7 +33,7 @@
       "config": {}
     },
     {
-      "id": "dummy",
+      "id": "dummy1",
       "name": "dummy",
       "type": "dummy",
       "url": "http://localhost",


### PR DESCRIPTION
## Motivation

Getting configuration by type was, in reality, searching the configuration by ID.
The same error was in keycloack configuration, where instead of the type, the id was checked.

JIRA: https://issues.jboss.org/browse/AEROGEAR-3332
