### PR TITLE
Application not starting when the service list in mobile-services.json was empty

### DIFF
--- a/Core/Core/MobileCore.cs
+++ b/Core/Core/MobileCore.cs
@@ -145,9 +145,9 @@ namespace AeroGear.Mobile.Core
 
         private async static void sendAppAndDeviceMetrics() 
         {
-            MetricsService metricsService = MobileCore.Instance.GetService<MetricsService>();
             try
             {
+                MetricsService metricsService = MobileCore.Instance.GetService<MetricsService>();
                 await metricsService.SendAppAndDeviceMetrics();    
             }
             catch (System.Exception e)
@@ -244,7 +244,7 @@ namespace AeroGear.Mobile.Core
             if (conf == null)
             {
                 ServiceConfiguration[] confs = GetServiceConfigurationByType(serviceModule.Type);
-                if (confs != null)
+                if (confs != null && confs.Length != 0)
                 {
                     result = confs[0];
                 }


### PR DESCRIPTION
## Motivation

- A NullPointer error was raised when no service was configured into mobile-services.json(ResolveConfiguration method)
- An error was raised by MobileCore when the metrics didn't have any configuration