### PR TITLE
Fix keycloak config username key

### DIFF
--- a/Auth/Auth/User/User.cs
+++ b/Auth/Auth/User/User.cs
@@ -22,7 +22,7 @@ namespace AeroGear.Mobile.Auth
         [JsonProperty(PropertyName = "name")]
         internal string Name { get; set; }
 
-        [JsonProperty(PropertyName = "preferred_name")]
+        [JsonProperty(PropertyName = "preferred_username")]
         internal string PreferredName { get; set; }
 
         [JsonProperty(PropertyName = "email")]


### PR DESCRIPTION
Currently the key used to extract a users username from Keycloak
is preferred_name, this is incorrect, the correct key is
preferred_username.

This currently causes retrieving the current user to fail unless a
first name has been set on the user.

This commit updates the key from preferred_name to preferred_username.

This is the original error.
````
System.ArgumentNullException: Value cannot be null.
Parameter name: 'username' can't be empty or null
  at AeroGear.Mobile.Core.Utils.SanityCheck.NonNull[T] (T value, System.String paramName) [0x0000f] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Core/Core/Utils/SanityCheck.cs:24
  at AeroGear.Mobile.Core.Utils.SanityCheck.NonEmpty (System.String value, System.Boolean trim, System.String customMessage, System.Object[] messageParams) [0x00001] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Core/Core/Utils/SanityCheck.cs:82
  at AeroGear.Mobile.Core.Utils.SanityCheck.NonEmpty (System.String value, System.String paramName) [0x00001] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Core/Core/Utils/SanityCheck.cs:38
  at AeroGear.Mobile.Auth.User..ctor (System.String username, System.String firstName, System.String lastName, System.String email, System.String identityToken, System.String accessToken, System.String refreshToken, System.Collections.Generic.IList`1[T] roles) [0x00008] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Auth/Auth/User/User.cs:148
  at AeroGear.Mobile.Auth.UserBuilder.op_Implicit (AeroGear.Mobile.Auth.UserBuilder ub) [0x00001] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Auth/Auth/User/User.cs:336
  at AeroGear.Mobile.Auth.Authenticator.OIDCAuthenticator.<Authenticate>b__5_0 (AeroGear.Mobile.Auth.Credentials.OIDCCredential credential, Foundation.NSError error) [0x0002e] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Auth/Auth.Platform.iOS/Authenticator/OIDCAuthenticator.cs:62
  at AeroGear.Mobile.Auth.Authenticator.OIDCAuthenticator+<>c__DisplayClass6_0.<startAuthorizationFlow>b__0 (OpenId.AppAuth.AuthState authState, Foundation.NSError error) [0x00022] in /Users/aidenkeating/work/xam/aerogear-xamarin-sdk/Auth/Auth.Platform.iOS/Authenticator/OIDCAuthenticator.cs:90
  at ObjCRuntime.Trampolines+SDAuthStateAuthorizationCallback.Invoke (System.IntPtr block, System.IntPtr authState, System.IntPtr error) [0x00023] in <2cd325e58f6243e8b54d78a48a653c17>:0
  at at (wrapper native-to-managed) ObjCRuntime.Trampolines+SDAuthStateAuthorizationCallback.Invoke(intptr,intptr,intptr)
  at at (wrapper managed-to-native) UIKit.UIApplication.UIApplicationMain(int,string[],intptr,intptr)
  at UIKit.UIApplication.Main (System.String[] args, System.IntPtr principal, System.IntPtr delegate) [0x00005] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.14.0.10/src/Xamarin.iOS/UIKit/UIApplication.cs:79
  at UIKit.UIApplication.Main (System.String[] args, System.String principalClassName, System.String delegateClassName) [0x0002c] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.14.0.10/src/Xamarin.iOS/UIKit/UIApplication.cs:63
  at myapp.Application.Main (System.String[] args) [0x00001] in /Users/aidenkeating/Projects/myapp/myapp/Main.cs:12
````