### PR TITLE
[WIP] Deprecate getRoles function due to naming

### DIFF
--- a/Auth/Auth.Tests/User/UserTest.cs
+++ b/Auth/Auth.Tests/User/UserTest.cs
@@ -48,6 +48,7 @@ namespace AeroGear.Mobile.Auth.Test
             Assert.AreEqual(user.IdentityToken, IDENTITY_TOKEN);
 
             Assert.AreEqual(2, user.getRoles().Count);
+            Assert.AreEqual(2, user.Roles.Count);
             Assert.IsTrue(user.HasRealmRole(ROLE1));
             Assert.IsTrue(user.HasResourceRole(ROLE2, NAMESPACE));
         }

--- a/Auth/Auth/User/User.cs
+++ b/Auth/Auth/User/User.cs
@@ -120,10 +120,18 @@ namespace AeroGear.Mobile.Auth
         /// <value>The refresh token.</value>
         public string RefreshToken { get; }
 
+        private List<UserRole> _roles;
+
         /// <summary>
         /// Roles associated with this principal.
         /// </summary>
-        public List<UserRole> Roles;
+        public ReadOnlyCollection<UserRole> Roles
+        {
+            get
+            {
+                return new ReadOnlyCollection<UserRole>(_roles);
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Aerogear.Mobile.Auth.User.User"/> class.
@@ -152,17 +160,19 @@ namespace AeroGear.Mobile.Auth
             this.IdentityToken = identityToken;
             this.AccessToken = accessToken;
             this.RefreshToken = refreshToken;
-            Roles = new List<UserRole>();
-            this.Roles.AddRange(roles);
+
+            this._roles = new List<UserRole>();
+            this._roles.AddRange(roles);
         }
 
         /// <summary>
         /// Gets the roles.
         /// </summary>
         /// <returns>All the roles associated with this user.</returns>
+        [Obsolete("getRoles is deprecated, use the Roles property instead.")]
         public ICollection<UserRole> getRoles()
         {
-            return new ReadOnlyCollection<UserRole>(Roles);
+            return new ReadOnlyCollection<UserRole>(_roles);
         }
 
         /// <summary>

--- a/docs/modules/getting-started/pages/auth.adoc
+++ b/docs/modules/getting-started/pages/auth.adoc
@@ -110,7 +110,7 @@ service.Authenticate(authOptions).ContinueWith(result =>
 
 var user = MobileCore.Instance.GetInstance<IAuthService>().CurrentUser();
 var roleItems = new List<string> { };
-foreach(var role in user.getRoles())
+foreach(var role in user.Roles)
 {
     roleItems.Add(role.ToString());
 }


### PR DESCRIPTION
Currently there is a function User#getRoles. This does not follow
the recommended naming convention for C# and does not follow the
naming conventions for the rest of the functions in the SDKs.

There is also a public field exposed on an instance of User named
Roles. This is not readonly and can be overwritten by an end user,
it exposes the list of roles that the user contains.

This change deprecates the function User#getRoles and recommends
to instead use the property Roles. It also refactors Roles from a
field into a readonly property without changing the return type
that the end user expects.

This means, apart from Roles no longer being modifiable for an end
user (which they shouldn't be doing anyway), the change is backwards
compatible.