### PR TITLE
Fix metrics not found error being thrown

### DIFF
--- a/Core/Core/MobileCore.cs
+++ b/Core/Core/MobileCore.cs
@@ -187,7 +187,14 @@ namespace AeroGear.Mobile.Core
             NonNull<Options>(options, "init options");
             instance = new MobileCore(injector, options);
 
-            sendAppAndDeviceMetrics();
+            try
+            {
+                sendAppAndDeviceMetrics();
+            }
+            catch (System.Exception e)
+            {
+                MobileCore.Instance.Logger.Debug(String.Format("Error publishing device metrics: {0}", e.Message));
+            }
 
             return instance;
         }


### PR DESCRIPTION
## Motivation

All other SDKs do not throw an error when sending app metrics fails.

## Description

Reintroduce the try catch block for sending metrics during initialization.
