### PR TITLE
Renamed Jailbreak check, added check methods to the security service

### DIFF
--- a/Security/Security.Platform.iOS/DeviceChecks.cs
+++ b/Security/Security.Platform.iOS/DeviceChecks.cs
@@ -19,7 +19,7 @@ namespace AeroGear.Mobile.Security
     {
         private static Dictionary<string, DeviceChecks> typesByName = new Dictionary<string, DeviceChecks>();
 
-        public static readonly DeviceChecks JAILBROKEN_ENABLED = new DeviceChecks(typeof(JailbrokenDeviceCheck));
+        public static readonly DeviceChecks JAILBREAK_ENABLED = new DeviceChecks(typeof(JailbrokenDeviceCheck));
         public static readonly DeviceChecks IS_EMULATOR = new DeviceChecks(typeof(IsEmulatorCheck));
         public static readonly DeviceChecks DEBUGGER_ATTACHED = new DeviceChecks(typeof(DebuggerAttachedCheck));
         public static readonly DeviceChecks DEVICE_LOCK_ENABLED = new DeviceChecks(typeof(DeviceLockEnabledCheck));

--- a/Security/Security/AbstractSecurityService.cs
+++ b/Security/Security/AbstractSecurityService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AeroGear.Mobile.Core;
 using AeroGear.Mobile.Core.Configuration;
+using AeroGear.Mobile.Core.Metrics;
 using AeroGear.Mobile.Core.Utils;
 using AeroGear.Mobile.Security.Executors;
 using AeroGear.Mobile.Security.Executors.Sync;
@@ -33,21 +34,23 @@ namespace AeroGear.Mobile.Security
             return new Builder();
         }
 
-        public DeviceCheckResult Check(IDeviceCheckType securityCheckType)
+        public DeviceCheckResult Check(IDeviceCheckType securityCheckType, MetricsService metricsService = null)
         {
             DeviceCheckResult[] results = new DeviceCheckResult[1];
             GetSyncExecutor()
                 .WithDeviceCheck(securityCheckType)
+                .WithMetricsService(metricsService)
                 .Build()
                 .Execute().Values.CopyTo(results, 0);
             return results[0];
         }
 
-        public DeviceCheckResult Check(IDeviceCheck securityCheck)
+        public DeviceCheckResult Check(IDeviceCheck securityCheck, MetricsService metricsService = null)
         {
             return DeviceCheckExecutor
                 .newSyncExecutor()
                 .WithDeviceCheck(securityCheck)
+                .WithMetricsService(metricsService)
                 .Build()
                 .Execute()[securityCheck.GetId()];
         }

--- a/Security/Security/ISecurityService.cs
+++ b/Security/Security/ISecurityService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using AeroGear.Mobile.Core;
+using AeroGear.Mobile.Core.Metrics;
 using AeroGear.Mobile.Security.Executors.Sync;
 
 namespace AeroGear.Mobile.Security
@@ -7,7 +8,7 @@ namespace AeroGear.Mobile.Security
     public interface ISecurityService : IServiceModule
     {
         Builder GetSyncExecutor();
-        DeviceCheckResult Check(IDeviceCheckType securityCheckType);
-        DeviceCheckResult Check(IDeviceCheck securityCheck);
+        DeviceCheckResult Check(IDeviceCheckType deviceCheckType, MetricsService metricsService = null);
+        DeviceCheckResult Check(IDeviceCheck deviceCheck, MetricsService metricsService = null);
     }
 }


### PR DESCRIPTION
## Motivation

Currently Xamarin Security service was no aligned with the one provided by other platforms (check method was missing).

Moreover there was a type in the JAILBREAK check.

## Description

Renamed the JAILBREAK from JAILBROKE_ENABLED to JAILBREAK_ENABLED
Added 2 check methods that optionally accepts the Metrics

## Progress

- [x] Rename JAILBROKE_ENABLED check to JAILBREAK_ENABLED
- [x] Add Check methods

